### PR TITLE
docs: add server.json as a first-class catalog type (application/mcp-server+json)

### DIFF
--- a/adr/0014-media-type-to-type.md
+++ b/adr/0014-media-type-to-type.md
@@ -29,6 +29,7 @@ The `type` field is an open text format, so any string value is accepted. To ens
 #### Integrated Ecosystem & Third-Party Types (Governed externally)
 - `application/a2a-agent-card+json` — A2A Agent Card
 - `application/mcp-server-card+json` — MCP Server Card
+- `application/mcp-server+json` — MCP Registry `server.json` document
 - `application/agent-skills+json` — Agent Skill Metadata json file
 - `application/agent-skills+md` — Agent Skill defined in a standard Markdown file (the suffix +md is to be registered)
 - `application/agent-skills+zip` — Agent Skill bundle in a ZIP archive

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -218,6 +218,7 @@ It MUST contain the following members:
 
     - `application/a2a-agent-card+json` — an A2A Agent Card
     - `application/mcp-server-card+json` — an MCP Server Card
+    - `application/mcp-server+json` — an MCP Registry `server.json` document
     - `application/agent-skills+json` — Agent Skill Metadata json file
     - `application/agent-skills+md` — an Agent Skill defined in a standard Markdown file (the suffix `+md` is to be registered)
     - `application/agent-skills+zip` — an Agent Skill bundle (ZIP archive)
@@ -1754,6 +1755,12 @@ to reference each server's **MCP Server Card**
 ([SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127))
 as the artifact content of a Catalog Entry.
 
+A Server Card is a static discovery document for a single HTTP-based MCP
+server (its identity and connection details). It is distinct from the MCP
+Registry's `server.json`, an installable-package descriptor — a separate
+artifact type mapped in
+[Mapping to MCP Registry server.json](#mapping-to-mcp-registry-server-json).
+
 ## Overview
 
 An MCP Server Card is a static discovery document for an individual
@@ -1932,6 +1939,161 @@ or trust layer. AI Catalog fills this gap:
    catalog format.
 6. **Composability**: MCP servers can be packaged with related
    artifacts (A2A agents, datasets) in nested catalogs.
+
+# Mapping to MCP Registry server.json
+
+This appendix describes how the MCP Registry `server.json` format
+(see [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry))
+maps to AI Catalog as a **first-class cataloged artifact type**, enabling
+installable MCP servers to be discovered alongside other AI artifacts
+through a unified catalog.
+
+> **Two MCP server artifacts, two types.** The MCP ecosystem defines two
+> distinct documents for a server, and AI Catalog gives each its own known
+> `type`:
+>
+> - **MCP Server Card** (`application/mcp-server-card+json`) — a static
+>   discovery document for a connectable HTTP server (identity, transport,
+>   capabilities, auth). See [Mapping to MCP Servers](#mapping-to-mcp-servers).
+> - **MCP Registry `server.json`** (`application/mcp-server+json`) — an
+>   installable **package descriptor** (package coordinates, transports,
+>   environment variables, CLI arguments).
+>
+> These are different artifacts, so they use different media types. The
+> Server Card deliberately uses `application/mcp-server-card+json` (not
+> `application/mcp-server+json`) to leave the unqualified `mcp-server`
+> name for the Registry `server.json` document
+> (modelcontextprotocol/experimental-ext-server-card issue #9 / PR #18).
+> A catalog entry references whichever artifact fits the use case — a
+> `server.json` for installable packages, a Server Card for connectable
+> endpoints — and a domain MAY list both.
+
+## Overview
+
+The MCP Registry defines a `server.json` format for describing MCP
+servers. Each `server.json` document captures everything needed to
+install, configure, and connect to a single MCP server: package
+coordinates (npm, PyPI, NuGet, OCI), remote endpoints (streamable-http,
+SSE), transport configuration, environment variables, and CLI arguments.
+
+In AI Catalog terms, a `server.json` document is the **artifact
+content** — the native metadata that a Catalog Entry references, declared
+with the known type `application/mcp-server+json`. AI Catalog does not
+duplicate or redefine `server.json` fields; it provides the discovery and
+trust layer that `server.json` does not address.
+
+## Conceptual Mapping
+
+| MCP `server.json` | AI Catalog Equivalent |
+|:---|:---|
+| `server.json` document (whole file) | Artifact content via entry `url` (type `application/mcp-server+json`) or `data` |
+| `name` (reverse-DNS identifier) | Entry `identifier` (mapped to the [`urn:air:{publisher}:{namespace}:{name}`](https://github.com/Agent-Card/ai-catalog/blob/main/adr/0015-agent-identifier-naming.md) URN form — e.g. registry name `com.pulsemcp/remote-filesystem` → `urn:air:pulsemcp.com:mcp:remote-filesystem`). The mapping is not a mechanical transliteration: `publisher` is the publisher's actual domain (e.g. `pulsemcp.com`) and `namespace` is a chosen category (e.g. `mcp`), independent of the registry name's reverse-DNS segments. |
+| `title` | Stays in the artifact (`server.json` carries its own `title`); entry `displayName` is omitted unless the artifact lacks a name |
+| `description` | Stays in the artifact (`server.json` carries its own `description`); entry `description` is omitted to avoid duplicating a value that can drift |
+| `version` | Stays in the artifact (`server.json` carries its own `version`); entry `version` is omitted unless the catalog lists multiple versions of one identifier (see [Multi-Version Entries](#multi-version-entries)) — the version-pinned `url` already identifies which version an entry points at |
+| `repository` | Stays in the artifact (`server.json` carries its own `repository`); omitted from the entry to avoid duplicating a value that can drift — catalog-level source/provenance links surface through the Trust Manifest when needed |
+| `packages[]` (npm, pypi, nuget, oci) | Inside the artifact — not surfaced in the catalog |
+| `remotes[]` (streamable-http, sse) | Inside the artifact — not surfaced in the catalog |
+| `environmentVariables[]` | Inside the artifact — not surfaced in the catalog |
+| `_meta` | Entry `metadata` for catalog-level hints; otherwise stays in the artifact — including the registry's own timestamps (`publishedAt`/`updatedAt` under `_meta`), so entry `updatedAt` is omitted to avoid duplicating a value the source already carries |
+| *(not in server.json)* | Entry `publisher` |
+| *(not in server.json)* | Entry `trustManifest` (identity, attestations, provenance) |
+| *(not in server.json)* | Entry `tags` for cross-artifact discovery |
+
+## MCP Server as Catalog Entry
+
+An MCP server published as a Registry `server.json` maps to a Catalog
+Entry whose `url` points to the `server.json` document and whose `type`
+is the known type `application/mcp-server+json`:
+
+```json
+{
+  "identifier": "urn:air:pulsemcp.com:mcp:remote-filesystem",
+  "type": "application/mcp-server+json",
+  "url": "https://registry.modelcontextprotocol.io/v0/servers/com.pulsemcp%2Fremote-filesystem/versions/0.1.5",
+  "tags": ["filesystem", "storage"],
+  "publisher": {
+    "identifier": "did:web:pulsemcp.com",
+    "displayName": "PulseMCP"
+  },
+  "trustManifest": {
+    "identity": "urn:air:pulsemcp.com:mcp:remote-filesystem",
+    "attestations": [
+      {
+        "type": "publisher-identity",
+        "uri": "https://trust.pulsemcp.com/certs/publisher.jwt"
+      }
+    ],
+    "provenance": [
+      {
+        "relation": "publishedFrom",
+        "sourceId": "https://github.com/pulsemcp/mcp-servers",
+        "registryUri": "https://registry.npmjs.org"
+      }
+    ]
+  }
+}
+```
+
+The `url` resolves to the server's `server.json`. In the MCP Registry, a
+specific version is addressed as
+`/v0/servers/{name}/versions/{version}` — where `{name}` is the server's
+reverse-DNS registry name, URL-encoded (the `/` between namespace and
+name becomes `%2F`) — and the response carries the `server.json` document
+in its `server` field alongside registry `_meta`. A client fetches the
+catalog entry for discovery and trust evaluation, then retrieves the
+`server.json` for operational details (packages, transports, env vars).
+
+## MCP Registry as AI Catalog
+
+The MCP Registry — a centralized index of MCP servers — can be
+represented as an AI Catalog. This lets clients that understand
+`application/ai-catalog+json` discover installable MCP servers alongside
+A2A agents, skills, and other artifacts:
+
+```json
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "MCP Server Registry",
+    "identifier": "did:web:modelcontextprotocol.io",
+    "documentationUrl": "https://modelcontextprotocol.io/docs"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:pulsemcp.com:mcp:remote-filesystem",
+      "type": "application/mcp-server+json",
+      "url": "https://registry.modelcontextprotocol.io/v0/servers/com.pulsemcp%2Fremote-filesystem/versions/0.1.5",
+      "tags": ["filesystem", "storage"]
+    },
+    {
+      "identifier": "urn:air:pulsemcp.com:mcp:pulse-fetch",
+      "type": "application/mcp-server+json",
+      "url": "https://registry.modelcontextprotocol.io/v0/servers/com.pulsemcp.servers%2Fpulse-fetch/versions/0.2.14",
+      "tags": ["fetch", "web"]
+    }
+  ]
+}
+```
+
+## Relationship to MCP Server Cards
+
+A Registry `server.json` and an MCP Server Card describe the same kind of
+thing at different lifecycle stages, and they layer naturally:
+
+`server.json` (`application/mcp-server+json`)
+: How do I **install and configure** this server? What packages,
+  transports, arguments, and environment variables does it need?
+
+Server Card (`application/mcp-server-card+json`)
+: How do I **connect to and use** this running server? What transport
+  endpoint, capabilities, tools, and authentication does it expose?
+
+A domain MAY publish both as separate catalog entries — one entry of each
+`type` pointing at the respective artifact — so clients can pick the
+representation that matches what they are doing (provisioning vs.
+connecting). AI Catalog provides the trust and cross-ecosystem indexing
+layer over both; each artifact carries its own protocol-specific detail.
 
 # Mapping to Claude Code Plugins Marketplace
 


### PR DESCRIPTION
> ⚠️ **AI-assisted draft.** This PR's content (spec prose and description) was drafted by an AI assistant working on Tadas's behalf. Tadas will review, vet, and rewrite as needed, and will remove this disclosure once he has done so. Until then, treat this as a steered placeholder, not Tadas's finished position.

## Stacked on #53

This PR is **stacked on top of #53** (`docs/update-server-json-mapping`). Its base branch is `docs/update-server-json-mapping`, not `main` — review/merge #53 first. The diff against its base is just the `server.json`-as-first-class change below.

## What this does

Reintroduces the MCP Registry `server.json` mapping that #53 removed, but as a **first-class cataloged artifact type** rather than an experimental footnote.

### Key changes

- **New known media type `application/mcp-server+json`** for an MCP Registry `server.json` document, registered in both the spec's known-types list and [ADR 0014](https://github.com/Agent-Card/ai-catalog/blob/main/adr/0014-media-type-to-type.md) (under "Integrated Ecosystem & Third-Party Types").
- **New appendix `Mapping to MCP Registry server.json`** describing the first-class mapping: a Catalog Entry whose `url` points to the `server.json` document with `type` `application/mcp-server+json`. Includes a conceptual mapping table, an entry example, an "MCP Registry as AI Catalog" example, and a "Relationship to MCP Server Cards" section.
- **Two-types framing.** The appendix is explicit that the MCP ecosystem has two distinct server artifacts, each with its own `type`:
  - **MCP Server Card** → `application/mcp-server-card+json` (static discovery / connection details)
  - **MCP Registry `server.json`** → `application/mcp-server+json` (installable package descriptor)

  A catalog entry references whichever fits; a domain MAY list both.

- **Examples use real MCP Registry URLs.** Every `server.json` example `url` uses the actual registry API form `https://registry.modelcontextprotocol.io/v0/servers/{url-encoded-name}/versions/{version}` (the `/` in the reverse-DNS name encoded as `%2F`), with verified-real servers/versions (`com.pulsemcp/remote-filesystem` 0.1.5, `com.pulsemcp.servers/pulse-fetch` 0.2.14). The appendix also explains how a registry name maps to the `urn:air:{publisher}:{namespace}:{name}` identifier per [ADR 0015](https://github.com/Agent-Card/ai-catalog/blob/main/adr/0015-agent-identifier-naming.md).

- **Omitted duplicative `version`/`description` from the example entries.** Mirrors the same change in #53's Server Card examples: these restate values the `server.json` document already carries (the drift argument that keeps `displayName` out of an entry). The example entries drop `version`/`description`; the conceptual mapping table keeps documenting them but its `description`/`version` rows justify the omission, parallel to the `title` row. For `server.json`, the entry's version-pinned `url` already identifies which version it points at.
- **Applied the same drift-avoidance treatment to `repository`.** `server.json` carries its own `repository`, so mapping it into entry `metadata.repository` duplicated a drift-prone value. The example already demonstrated the redundancy — the repo URL also appears in `trustManifest.provenance[].sourceId` — so the `metadata.repository` block is dropped from the example and the table row now justifies the omission (source/provenance links belong in the Trust Manifest). This mirrors the Server Card `repository` fix inherited from #53.
- **Dropped `updatedAt` from the entry example (registry-timestamp drift).** The single-entry example carried `"updatedAt": "2026-03-15T10:00:00Z"`, but the MCP Registry response already exposes its own `publishedAt`/`updatedAt` under `_meta` (verified live: `registry.modelcontextprotocol.io` returns `_meta["io.modelcontextprotocol.registry/official"].updatedAt`), so the entry field duplicated a value the source carries — and the hardcoded date had already drifted from the real one. Removed it from the example (bringing it to structural parity with #53's Server Card entry example, which carries no `updatedAt`) and extended the `_meta` mapping-table row to record that the registry timestamps stay in the artifact.
- **`version` keeps its multi-version carve-out here (deliberate divergence from the Server Card side).** #53 dropped the multi-version carve-out from the Server Card `version` row because a remote MCP server serves exactly one card. On the Registry `server.json` side that case is real — a registry genuinely serves multiple versions of a name — so this appendix's `version` row retains the "omitted unless the catalog lists multiple versions of one identifier" language, plus the note that the version-pinned `url` already identifies which version an entry points at.

### Note on the naming distinction (issue #9 / PR #18)

ext-server-card issue #9 / PR #18 deliberately chose `application/mcp-server-card+json` for the **Server Card** so it would *not* collide with the Registry `server.json` concept. This PR is the other half of that decision: it allocates the unqualified `application/mcp-server+json` to the Registry `server.json` document itself. The two types are complementary, not competing.

## Verification

- [x] **Spec builds locally** with the exact CI command (`python tools/build_spec.py`), exit 0, `dist/index.html` produced.
- [x] **New type registered in both places** — `application/mcp-server+json` appears in the spec known-types list and ADR 0014 (verified the HTML renders it; 11 occurrences in built output across the new appendix + lists).
- [x] **Cross-reference resolves** — the appendix's link to `#mapping-to-mcp-servers` matches the generated heading `id` (verified in built HTML).
- [x] **No new broken anchors** — built-HTML link/`id` audit shows the only unresolved anchors (`metadata-extensibility`, `resolving-an-artifacts-display-name`, `version-handling`) are **pre-existing on `main`**; none are introduced or referenced by this change.
- [x] **All JSON examples valid** and use `type: "application/mcp-server+json"` with `urn:air:` identifiers.
- [x] **Duplicative fields removed cleanly** — no `server.json` example entry carries `version`/`description`/`metadata.repository`/`updatedAt` (grep confirmed the appendix's only remaining `updatedAt` is the explanatory `_meta` table row, not an example value); version remains recoverable from the version-pinned `url`, the repo from `trustManifest.provenance`, and the timestamps from the registry `_meta`; the mapping table keeps documenting `version`/`description`/`repository`/`_meta`, each with its omission rationale. All 19 JSON examples still parse.
- [x] **Registry-timestamp drift verified live** — `curl` of `registry.modelcontextprotocol.io/v0/servers/com.pulsemcp%2Fremote-filesystem/versions/0.1.5` returns `_meta["io.modelcontextprotocol.registry/official"]` with `publishedAt`/`updatedAt` (`2026-06-26…`), confirming the removed entry `updatedAt` was both duplicative and stale against the source.
- [x] **Example URLs verified against the live registry** — both example URLs (`com.pulsemcp%2Fremote-filesystem/versions/0.1.5`, `com.pulsemcp.servers%2Fpulse-fetch/versions/0.2.14`) return HTTP 200 from `registry.modelcontextprotocol.io`, with response `server.name`/`version`/`repository` matching the example values; the prose's `/v0/servers/{name}/versions/{version}` + `server`/`_meta` envelope description was confirmed against that response.
- [x] **Inherits #53's discovery-flow reframe** — the shared Server Card appendix's "Decentralized Discovery" section (reframed per [ext-server-card PR #36](https://github.com/modelcontextprotocol/experimental-ext-server-card/pull/36)) merges in cleanly; build passes on this branch.
- [x] **Fresh-eyes review** performed in-process on the diff vs. the base branch; feedback addressed.
- [x] **CI green** on the latest commit (confirmed via wait-for-CI after the final push).

## Status

**Draft — do not merge.** Stacked on #53; awaiting Tadas's review and rewrite.


