### PR TITLE
fix: make the Trust Manifest MUST rules satisfiable by the spec's own examples

### DIFF
--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -513,15 +513,16 @@ A Trust Manifest MUST contain:
   DID, SPIFFE ID, or URL; these are illustrative and the set of
   identity schemes is open.
 
-When a Trust Manifest appears within a Catalog Entry, the `identity`
-field's trust domain MUST align with the publisher domain in the
-containing entry's `identifier` field. This binding ensures
-trust claims are associated with the authorized publisher namespace even
-when `identity` and `identifier` use different URI schemes.
-Consumers MUST reject a Trust Manifest whose `identity` domain does not
-align with the publisher domain in the containing entry's `identifier`.
-The `identity` is carried here so domain binding is part of the signed
-payload, rather than inferred only from unsigned entry context.
+When a Trust Manifest appears within a Catalog Entry whose
+`identifier` uses the `urn:air` naming format, consumers MUST
+extract the publisher domain from the identifier and verify that
+the `identity` field's authority or trust domain aligns with it.
+Consumers MUST reject a Trust Manifest whose identity domain does
+not align with the extracted publisher domain. For all other
+identifier formats, the identifier is opaque to the trust
+verification process; consumers MUST NOT attempt to derive a
+publisher domain from it and SHOULD rely on other verification
+instead, such as attestations or signature verification.
 
 When a Trust Manifest appears on a Host Info object, `identity`
 SHOULD match the host's `identifier` field when present.


### PR DESCRIPTION
Fixes #70.

Two normative MUSTs could not be satisfied by the Claude Plugins appendix examples:

1. The identity binding rule assumed every `identifier` has a publisher domain segment, but `identifier` is an open format and the appendix uses `urn:claude-plugin:...` identifiers with no domain at all. A consumer following the rule as written would have to reject the Trust Manifests in the spec's own examples. The rule is now scoped to identifiers that carry a publisher domain segment (such as the `urn:air` form), with a fallback to other verification (attestations, signatures) for formats that don't.

2. Digest Format requires consumers to reject digests weaker than SHA-256, yet the appendix mapped the marketplace's git commit `sha` to `sourceDigest` as `sha1:...`. A commit SHA is a revision identifier, not a content digest of anything a consumer can fetch and hash, so the mapping now lands it in entry `metadata.sourceSha` instead, and the examples no longer carry `sourceDigest` values that consumers are required to reject.

A dedicated `sourceRevision` field on the Provenance Link (as floated in the issue) would be a schema addition and would need its own ADR, so it is intentionally out of scope here.