### PR TITLE
docs: add tomevault-io/ai-catalog-reference to implementations

### DIFF
--- a/docs/implementations.md
+++ b/docs/implementations.md
@@ -5,4 +5,5 @@ This page lists various implementations and testbeds for the AI Catalog specific
 - [spec-works/ai-catalog](https://github.com/spec-works/ai-catalog) (C#, Python)
 - [ai-catalog-go-sdk](https://github.com/agntcy/ai-catalog-go-sdk/) (Go)
 - [ai-catalog-rust](https://github.com/agntcy/ai-catalog-rust) (Rust)
+- [tomevault-io/ai-catalog-reference](https://github.com/tomevault-io/ai-catalog-reference) (Python, Trust Manifest signer/verifier)
 - [AI Catalog](https://ai-catalog.outshift.io/) (testbed service)


### PR DESCRIPTION
Adds TomeVault's implementation to the list.

Apache-2.0, Python, covering the Trust Manifest layer: detached EdDSA JWS over JCS, subject binding, identity anchoring, freshness, and SSRF-safe fetch. It also ships a vector suite that runs the ADR-0009 substitution attack both ways, so the subject binding can be checked against running code rather than read in prose.

Disclosure: I work on TomeVault, where we find what has gone wrong in a team's AI instruction files, sign the corrected version, and keep watching for the next time it drifts. We do that across every tool and format, since no vendor checks another's, which is why a shared trust layer matters to us and why this exists.

Docs only, no specification text changed.
