### PR TITLE
feat: add application/agent-plugin+json as a recognized catalog entry type

### DIFF
--- a/docs/guides/creating-a-catalog.md
+++ b/docs/guides/creating-a-catalog.md
@@ -89,7 +89,10 @@ Every entry must have these three things:
 | Agent Skill (Markdown) | `application/agent-skills+md` |
 | Agent Skill (ZIP bundle) | `application/agent-skills+zip` |
 | Agent Skill (gzipped tarball) | `application/agent-skills+gzip` |
+| Agent Plugin manifest | `application/agent-plugins+json` |
 | Dataset | `application/parquet`, `text/csv`, or appropriate type |
+
+An **Agent Plugin** ([agent-plugins.org](https://agent-plugins.org)) is a portable package bundling Agent Skills and MCP servers into a single distributable unit. The catalog entry's `url` points to the plugin's `plugin.json` manifest — the machine-readable descriptor clients use for discovery. Loading and executing the full plugin requires the complete plugin directory, distributed out-of-band (e.g., via git or a package registry).
 
 This list is not exhaustive — AI Catalog accepts any string as a `type` value. The spec is intentionally artifact-agnostic.
 

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -131,7 +131,7 @@ For example, a minimal catalog listing four AI artifacts:
       "url": "https://agents.example.com/researchAssistant"
     },
     {
-      "identifier": "urn:air:example.com:plugin:productivity",
+      "identifier": "urn:air:example.com:agent:productivity-plugin",
       "displayName": "Productivity Plugin",
       "type": "application/agent-plugin+json",
       "url": "https://plugins.example.com/productivity/plugin.json"

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -133,7 +133,7 @@ For example, a minimal catalog listing four AI artifacts:
     {
       "identifier": "urn:air:example.com:agent:productivity-plugin",
       "displayName": "Productivity Plugin",
-      "type": "application/agent-plugin+json",
+      "type": "application/agent-plugins+json",
       "url": "https://plugins.example.com/productivity/plugin.json"
     }
   ]
@@ -228,7 +228,7 @@ It MUST contain the following members:
     - `application/agent-skills+md` — an Agent Skill defined in a standard Markdown file (the suffix `+md` is to be registered)
     - `application/agent-skills+zip` — an Agent Skill bundle (ZIP archive)
     - `application/agent-skills+gzip` — an Agent Skill bundle (gzipped tarball)
-    - `application/agent-plugin+json` — an Agent Plugin manifest ([Agent Plugins specification](https://agent-plugins.org/specification))
+    - `application/agent-plugins+json` — an Agent Plugin manifest ([Agent Plugins specification](https://agent-plugins.org/specification))
 
     These values are designed to align with official IANA media type registration standards. Standard ecosystem types use registered structured syntax suffixes (`+json`, `+zip`, `+gzip`). For any new or custom types not listed here, it is up to the specific client implementation to handle them correctly.
 

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -108,7 +108,7 @@ members:
 : An array of Catalog Entry objects as defined in [Catalog Entry](#catalog-entry).
   This array MAY be empty.
 
-For example, a minimal catalog listing three AI artifacts:
+For example, a minimal catalog listing four AI artifacts:
 
 ```json
 {
@@ -129,6 +129,12 @@ For example, a minimal catalog listing three AI artifacts:
       "identifier": "urn:air:example.com:a2a:research",
       "type": "application/a2a-agent-card+json",
       "url": "https://agents.example.com/researchAssistant"
+    },
+    {
+      "identifier": "urn:air:example.com:plugin:productivity",
+      "displayName": "Productivity Plugin",
+      "type": "application/agent-plugin+json",
+      "url": "https://plugins.example.com/productivity/plugin.json"
     }
   ]
 }
@@ -222,6 +228,7 @@ It MUST contain the following members:
     - `application/agent-skills+md` — an Agent Skill defined in a standard Markdown file (the suffix `+md` is to be registered)
     - `application/agent-skills+zip` — an Agent Skill bundle (ZIP archive)
     - `application/agent-skills+gzip` — an Agent Skill bundle (gzipped tarball)
+    - `application/agent-plugin+json` — an Agent Plugin manifest ([Agent Plugins specification](https://agent-plugins.org/specification))
 
     These values are designed to align with official IANA media type registration standards. Standard ecosystem types use registered structured syntax suffixes (`+json`, `+zip`, `+gzip`). For any new or custom types not listed here, it is up to the specific client implementation to handle them correctly.
 

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -30,7 +30,7 @@
       "updatedAt": "2026-02-22T16:00:00Z"
     },
     {
-      "identifier": "urn:air:acme-corp.com:agent:finance-assistant-plugin",
+      "identifier": "urn:air:acme-corp.com:plugin:finance-assistant-plugin",
       "displayName": "Finance Assistant Plugin",
       "type": "application/agent-plugins+json",
       "description": "Agent Plugin bundle with skills and MCP server for finance workflows.",

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -28,6 +28,20 @@
       ],
       "url": "https://data.acme-corp.com/datasets/market-dataset-2026q1.parquet",
       "updatedAt": "2026-02-22T16:00:00Z"
+    },
+    {
+      "identifier": "urn:air:acme-corp.com:plugin:finance-assistant",
+      "displayName": "Finance Assistant Plugin",
+      "type": "application/agent-plugin+json",
+      "description": "Agent Plugin bundle with skills and MCP server for finance workflows.",
+      "tags": [
+        "finance",
+        "plugin",
+        "skills",
+        "mcp"
+      ],
+      "url": "https://plugins.acme-corp.com/finance-assistant/plugin.json",
+      "updatedAt": "2026-02-22T16:00:00Z"
     }
   ]
 }

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -30,7 +30,7 @@
       "updatedAt": "2026-02-22T16:00:00Z"
     },
     {
-      "identifier": "urn:air:acme-corp.com:plugin:finance-assistant",
+      "identifier": "urn:air:acme-corp.com:agent:finance-assistant-plugin",
       "displayName": "Finance Assistant Plugin",
       "type": "application/agent-plugin+json",
       "description": "Agent Plugin bundle with skills and MCP server for finance workflows.",

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -32,7 +32,7 @@
     {
       "identifier": "urn:air:acme-corp.com:agent:finance-assistant-plugin",
       "displayName": "Finance Assistant Plugin",
-      "type": "application/agent-plugin+json",
+      "type": "application/agent-plugins+json",
       "description": "Agent Plugin bundle with skills and MCP server for finance workflows.",
       "tags": [
         "finance",


### PR DESCRIPTION
## Add \`application/agent-plugins+json\` to known types

**What**
- Adds \`application/agent-plugins+json\` to the Integrated Ecosystem & Third-Party Types list, referencing the [Agent Plugins specification](https://agent-plugins.org/specification)
- Updates the prose example count (three → four AI artifacts) with a new plugin entry
- Adds a plugin entry to \`specification/examples/ai-catalog.json\`

**Why**
Agent Plugins is an emerging standard (TSC: Amazon, Cursor, Microsoft, OpenAI, Vercel) for bundling Agent Skills + MCP servers into a single distributable unit. Both constituent types (\`agent-skills+json\`, \`mcp-server-card+json\`) are already in the list; this registers the envelope/manifest type alongside them. \`+json\` suffix is correct per RFC 6838 — \`plugin.json\` is a JSON object.

**Implementation note: discovery, not delivery**
Agent Plugins v1 is a filesystem-only format — no HTTP fetch/install mechanism is defined (distribution is in FUTURE_CONSIDERATIONS). A catalog entry's \`url\` points to \`plugin.json\` (the manifest), which is the right analogy: the same as \`a2a-agent-card+json\` pointing at an agent card rather than a running agent, or \`mcp-server-card+json\` pointing at a server card rather than a running server. The catalog entry enables **discovery** (read manifest metadata); full execution requires the whole plugin directory via out-of-band delivery (git clone, zip, registry). This is acceptable for catalog purposes.

**Choices made**
- **Third-party placement** — governed externally (Agent Plugins TSC, not AI Catalog WG); Core section would be wrong
- **Plural \`agent-plugins+json\`** — matches \`agent-skills+json\` pattern; singular would be inconsistent
- **Description: "an Agent Plugin manifest"** — precise; \`plugin.json\` is what the spec calls the manifest; consistent with "an A2A Agent Card" / "an MCP Server Card"
- **\`url\` → \`plugin.json\`** — correct discovery target; same pattern as agent-card and server-card types
- **No governance annotation** — no existing third-party entry has one; adding here alone would be inconsistent
- **No "bundles X+Y" note** — redundant with the linked spec

**Non-goals**
- IANA registration — Agent Plugins TSC's responsibility
- Claude Code plugin support — pre-existing gap in known-types (mentioned in spec prose, no media type listed); separate discussion needed
- Fixing governance annotations across all third-party entries
- Defining a plugin distribution/fetch mechanism — that's Agent Plugins FUTURE_CONSIDERATIONS

**Open question for WG — resolve before merge**
Agent Plugins spec page says **"Working Draft"**; GitHub README says **"Published"**. These are materially different. Confirm canonical status with the Agent Plugins TSC.

**CI:** \`uv run --locked python tools/build_spec.py\` passes. JSON examples validated.