### PR TITLE
docs: add Community page, section indexes, and nav icons

### DIFF
--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -1,0 +1,25 @@
+---
+icon: material/account-group
+---
+
+# Community
+
+The AI Catalog specification is developed openly under the Linux Foundation's Agent Card Working Group. Everyone is welcome to participate.
+
+## Chat
+
+Join the conversation on Discord — ask questions, share feedback, and connect with other implementers and contributors.
+
+[:fontawesome-brands-discord: Join the AI Catalog Discord](https://discord.gg/wh4XQQG4tt){ .md-button }
+
+## Community Meetings
+
+The working group holds regular community meetings open to all. Come discuss the spec roadmap, raise issues, and meet the contributors.
+
+[:octicons-video-16: Join the Community Meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/91656063701?password=946db53a-d3d4-4dd2-a8d5-5ed46ae035d3){ .md-button }
+
+## Contributing
+
+The specification and all tooling live on GitHub. Contributions of all kinds are welcome — bug reports, spec proposals, documentation improvements, and code.
+
+[:fontawesome-brands-github: Agent-Card/ai-catalog on GitHub](https://github.com/Agent-Card/ai-catalog){ .md-button }

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,11 @@
+---
+icon: material/code-json
+---
+
+# Examples
+
+Annotated catalog documents illustrating common patterns and conformance levels.
+
+- [Minimal Catalog](minimal-catalog.md) — the simplest valid catalog (Level 1 conformance)
+- [Multi-Protocol Agent](multi-protocol-agent.md) — a single agent entry spanning MCP and A2A
+- [Nested Catalogs](nested-catalogs.md) — enterprise-scale organisation with hierarchical sub-catalogs

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,7 @@
+---
+icon: material/rocket-launch
+---
+
 # Getting Started
 
 This guide gets a working AI Catalog live in about 5 minutes.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,13 @@
+---
+icon: material/book-open-variant
+---
+
+# Guides
+
+Step-by-step guides for working with AI Catalog as an author, publisher, or consumer.
+
+- [Creating a Catalog](creating-a-catalog.md) — author a well-formed catalog from scratch
+- [Organizing Catalogs](organizing-catalogs.md) — use nesting and federation for large inventories
+- [Consuming Catalogs](consuming-catalogs.md) — discover, fetch, and process catalogs as a client
+- [Serving Your Catalog](serving-your-catalog.md) — distribution models and hosting options
+- [Adding Trust](adding-trust.md) — verifiable identity and compliance attestations via the Trust Manifest

--- a/docs/implementations.md
+++ b/docs/implementations.md
@@ -1,8 +1,23 @@
+---
+icon: material/code-braces
+---
+
 # Implementations
 
-This page lists various implementations and testbeds for the AI Catalog specification.
+This page lists implementations and tooling for the AI Catalog specification.
+
+## Official
+
+These implementations are maintained by the Agent Card Working Group or its member organisations.
 
 - [spec-works/ai-catalog](https://github.com/spec-works/ai-catalog) (C#, Python)
 - [ai-catalog-go-sdk](https://github.com/agntcy/ai-catalog-go-sdk/) (Go)
 - [ai-catalog-rust](https://github.com/agntcy/ai-catalog-rust) (Rust)
 - [AI Catalog](https://ai-catalog.outshift.io/) (testbed service)
+
+## Community Projects
+
+Community-built tools, libraries, and integrations. Listed here to help discovery — not formally endorsed by the working group.
+
+!!! tip "Add your project"
+    Have an implementation to share? Open a pull request to add it here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+icon: material/home
+---
+
 # AI Catalog
 
 **A JSON format for making all your AI artifacts discoverable.**

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,3 +1,7 @@
+---
+icon: material/file-document
+---
+
 # Full Specification
 
 The AI Catalog specification is published as a W3C-style normative document.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,10 +33,11 @@ theme:
     - navigation.instant
     - navigation.instant.prefetch
     - navigation.tracking
-    - navigation.sections
     - navigation.expand
     - navigation.top
     - navigation.footer
+    - navigation.indexes
+    - navigation.sections
     - search.suggest
     - search.highlight
     - content.code.copy
@@ -75,21 +76,26 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/Agent-Card/ai-catalog
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/wh4XQQG4tt
 
 nav:
   - Home: index.md
   - Specification: specification.md
   - Getting Started: getting-started.md
   - Guides:
+      - guides/index.md
       - Creating a Catalog: guides/creating-a-catalog.md
       - Organizing Catalogs: guides/organizing-catalogs.md
       - Consuming Catalogs: guides/consuming-catalogs.md
       - Serving Your Catalog: guides/serving-your-catalog.md
       - Adding Trust: guides/adding-trust.md
   - Examples:
+      - examples/index.md
       - Minimal Catalog: examples/minimal-catalog.md
       - Multi-Protocol Agent: examples/multi-protocol-agent.md
       - Nested Catalogs: examples/nested-catalogs.md
   - Implementations: implementations.md
+  - Community: community/index.md
 
 


### PR DESCRIPTION
## Summary

- Add a new **Community** page (`docs/community/index.md`) with links to the Discord server and the Linux Foundation community Zoom meeting
- Add a Discord social icon to the site footer in `mkdocs.yml`
- Split `implementations.md` into **Official** and **Community Projects** sections, with a tip prompting people to add their own projects via PR
- Add `index.md` overview pages to `docs/guides/` and `docs/examples/` with brief descriptions of each child page
- Add navigation icons via frontmatter to all top-level pages (`home`, `file-document`, `rocket-launch`, `code-braces`, `account-group`) and the new section indexes
- Enable `navigation.indexes` in `mkdocs.yml` so section headers in the nav link directly to their index pages