### PR TITLE
feat(spec): add Deployment official extension (resolves #64)

### DIFF
--- a/adr/0022-deployment-metadata-extension.md
+++ b/adr/0022-deployment-metadata-extension.md
@@ -1,0 +1,95 @@
+# ADR-0022: Deployment Metadata as an Official Extension
+
+## Status
+Accepted
+
+## Date
+2026-08-05
+
+## Context
+[Issue #64](https://github.com/Agent-Card/ai-catalog/issues/64)
+observes that a Catalog Entry conflates *identity* ("what the agent is")
+with *instance* ("where it lives"). The entry's `identifier` names a
+single logical artifact, and its `url` names a single entry point — yet
+the same logical agent is routinely deployed many times: across
+environments (development, staging, production), across release channels
+(stable, beta, LTS, edge), and across regions (us-east, eu-west) that
+carry differing data-residency and compliance constraints.
+
+Enterprise consumers need to discover and select among these deployments
+deterministically: an EU client must reach an EU instance subject to
+GDPR, a test harness must reach staging, and shadow-testing a pre-release
+release channel must be possible — all while the artifact keeps a single
+logical identity. The
+core entry schema, which is intentionally closed (see
+[ADR-0012](0012-extensibility-via-metadata.md)), has no place to express
+this, and there is no interoperable convention for it today.
+
+## Decision
+Deployment metadata is defined as an **official extension**, registered
+at the extension key
+`https://ai-catalog.org/extensions/deployment`, and carried in the
+entry's `extensions` map. It is **not** added as a native `instances`
+field on the entry.
+
+The extension value is a JSON object with a REQUIRED, non-empty
+`instances` array. Each Instance object carries:
+
+- `instanceId` (REQUIRED, string) — stable identifier, unique within the
+  entry.
+- `url` (REQUIRED, string) — entry-point URL for this instance.
+- `environment` (OPTIONAL, string) — e.g. `production`, `staging`,
+  `development`.
+- `releaseChannel` (OPTIONAL, string) — release maturity track, orthogonal
+  to `environment`; e.g. `stable`, `beta`, `LTS`, `EDGE`.
+- `region` (OPTIONAL, string) — e.g. `us-east-1`, `eu-west-1`.
+- `dataResidency` (OPTIONAL, array of strings) — jurisdictions where data
+  is stored or processed.
+- `compliance` (OPTIONAL, array of strings) — compliance regimes the
+  instance conforms to.
+- `description` (OPTIONAL, string) — human-readable label.
+
+The entry's top-level `url` remains the DEFAULT entry point for the
+artifact, and one instance `url` SHOULD equal it. Each instance is an
+alternative endpoint for the SAME logical artifact (same `identifier`);
+instances are deployments, not distinct artifacts. A consumer that does
+not understand the key MUST ignore it and fall back to the entry `url`; a
+consumer that does understand it MAY select an instance matching its
+policy and, if none matches, SHOULD NOT fall back to a non-conforming
+instance. All identifiers use the `urn:air` format mandated by
+[ADR-0015](0015-agent-identifier-naming.md).
+
+## Rationale
+- Keeps the core entry schema closed and stable, consistent with the
+  closed-core philosophy of
+  [ADR-0012](0012-extensibility-via-metadata.md); a not-yet-universal
+  need does not force a change to the core.
+- Consumers that do not recognize the key ignore it safely and fall back
+  to the entry `url`, guaranteed by the existing `extensions` rule.
+- The extension can evolve independently without requiring a major
+  version bump of the specification.
+- Aligns with the precedent already set by the Metadata official
+  extension (`https://ai-catalog.org/extensions/metadata`).
+
+## Alternatives Considered
+- **Native `instances` field on the entry** — Rejected. It bloats the
+  closed core for a need that is not universal and reopens the schema
+  evolution problem ADR-0012 was written to avoid.
+- **Separate curated catalogs per compliance regime** — Rejected as
+  inflexible (per the issue's own analysis): it multiplies catalogs,
+  duplicates identity, and cannot express a single logical artifact with
+  many deployments.
+- **Freeform vendor metadata** — Rejected. Ad-hoc, per-vendor keys give
+  no interoperability, so no consumer could select instances
+  deterministically across producers.
+
+## Consequences
+- Instance selection becomes deterministic and interoperable across
+  producers and consumers.
+- The metadata is advisory. It is unsigned unless carried in a Trust
+  Manifest's `extensions`, and MUST NOT be treated as a security control
+  on its own; `dataResidency` and `compliance` are producer assertions
+  that a consumer needing assurance verifies via the Trust Manifest
+  (attestations), not via this extension.
+- The official extensions registry gains one entry:
+  `https://ai-catalog.org/extensions/deployment`.

--- a/docs/examples/deployment-metadata.md
+++ b/docs/examples/deployment-metadata.md
@@ -1,0 +1,145 @@
+# Example: Deployment Metadata
+
+A single logical agent often runs in more than one place: production and
+staging, `us-east-1` and `eu-west-1`, with different data-residency and
+compliance constraints in each region. AI Catalog keeps **identity** ("what
+the agent is") separate from **instance** ("where it lives"): the entry has one
+stable `identifier`, and the [Deployment official extension](../specification.md)
+enumerates the concrete deployment instances behind it.
+
+This lets a consumer deterministically pick an instance that satisfies its
+policy — an EU client selecting the GDPR instance in `eu-west-1`, a test harness
+targeting `staging`, or a client opting into a `beta` release channel — while
+everything stays under one logical identity.
+
+## The extension
+
+The extension key (namespace) is:
+
+```
+https://ai-catalog.org/extensions/deployment
+```
+
+It lives inside an entry's `extensions` map. Its value is an object with a
+required, non-empty `instances` array. Each instance describes one deployment of
+the **same** logical artifact — instances are deployments, not distinct
+artifacts.
+
+!!! note "The entry `url` stays the default"
+    The entry's top-level `url` remains the default entry point. Each instance's
+    `url` is an alternative endpoint for the same `identifier`. One instance
+    `url` should equal the entry `url` so the default is represented among the
+    instances.
+
+## Full example
+
+```json
+{
+  "identifier": "urn:air:acme-corp.com:agent:invoice-processor",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme-corp.com/agents/invoice",
+  "tags": ["finance", "a2a"],
+  "extensions": {
+    "https://ai-catalog.org/extensions/deployment": {
+      "instances": [
+        {
+          "instanceId": "invoice-prod-us",
+          "environment": "production",
+          "url": "https://api.acme-corp.com/agents/invoice",
+          "region": "us-east-1"
+        },
+        {
+          "instanceId": "invoice-prod-eu",
+          "environment": "production",
+          "url": "https://eu-api.acme-corp.com/agents/invoice",
+          "region": "eu-west-1",
+          "dataResidency": ["EU"],
+          "compliance": ["GDPR"]
+        },
+        {
+          "instanceId": "invoice-staging",
+          "environment": "staging",
+          "url": "https://staging-api.acme-corp.com/agents/invoice",
+          "region": "us-east-1",
+          "releaseChannel": "beta"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Instance fields
+
+Each object in the `instances` array supports these fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `instanceId` | string | Required | Stable identifier for this instance, unique within the entry |
+| `url` | string | Required | Entry-point URL for this instance |
+| `environment` | string | Optional | Deployment environment, e.g. `production`, `staging`, `development` |
+| `releaseChannel` | string | Optional | Release maturity track, orthogonal to `environment`, e.g. `stable`, `beta`, `LTS`, `EDGE` |
+| `region` | string | Optional | Deployment region, e.g. `us-east-1`, `eu-west-1` |
+| `dataResidency` | string[] | Optional | Jurisdictions where data is stored or processed, e.g. `["EU"]`, `["US","CA"]` |
+| `compliance` | string[] | Optional | Compliance regimes the instance conforms to, e.g. `["GDPR"]`, `["SOC2","HIPAA"]` |
+| `description` | string | Optional | Human-readable label for the instance |
+
+## Selecting an instance
+
+A consumer that understands the extension may select an instance whose
+`environment`, `region`, `dataResidency`, or `compliance` satisfies its policy.
+If no instance matches, it **should not** fall back to a non-conforming instance.
+
+```python
+DEPLOYMENT_KEY = "https://ai-catalog.org/extensions/deployment"
+
+def select_instance(entry, environment=None, release_channel=None,
+                    region=None, compliance=None):
+    """Pick a deployment instance matching the consumer's policy.
+
+    Returns None when no instance conforms — don't fall back
+    to a non-conforming instance (e.g. the entry url) in that case.
+    """
+    ext = entry.get("extensions", {}).get(DEPLOYMENT_KEY)
+    if not ext:
+        # Extension unknown/absent: fall back to the entry's default url.
+        return {"url": entry["url"]}
+
+    for inst in ext["instances"]:
+        if environment and inst.get("environment") != environment:
+            continue
+        if release_channel and inst.get("releaseChannel") != release_channel:
+            continue
+        if region and inst.get("region") != region:
+            continue
+        if compliance and compliance not in inst.get("compliance", []):
+            continue
+        return inst
+
+    return None  # no conforming instance — do not fall back
+```
+
+```python
+entry = ...  # the invoice-processor entry above
+
+# EU client bound by GDPR: resolves to the eu-west-1 instance.
+eu = select_instance(entry, region="eu-west-1", compliance="GDPR")
+
+# Test harness: resolves to the staging instance.
+staging = select_instance(entry, environment="staging")
+
+# Client opting into the beta release channel: resolves to the beta instance.
+beta = select_instance(entry, release_channel="beta")
+```
+
+!!! warning "Deployment metadata is not a trust control"
+    `dataResidency` and `compliance` are producer assertions, not signed
+    claims. A consumer that needs assurance verifies them via the entry's Trust
+    Manifest (attestations), not via this extension. A consumer that does not
+    understand the extension key ignores it and falls back to the entry `url`.
+
+## Related
+
+- [Full Specification](../specification.md)
+- [Creating a Catalog](../guides/creating-a-catalog.md#the-deployment-extension)
+- [Consuming Catalogs](../guides/consuming-catalogs.md#selecting-a-deployment-instance)

--- a/docs/guides/consuming-catalogs.md
+++ b/docs/guides/consuming-catalogs.md
@@ -104,6 +104,42 @@ def resolve_artifact(entry):
 
 When fetching from `url`, the server should respond with the content type declared in the entry's `type` field.
 
+## Selecting a deployment instance
+
+An entry may carry the [Deployment extension](../examples/deployment-metadata.md)
+in its `extensions` map, listing the concrete instances of one logical artifact
+across environments, release channels, and regions. A consumer that understands
+the extension may pick the instance matching its
+environment/releaseChannel/region/compliance policy instead of the default entry
+`url`:
+
+```python
+DEPLOYMENT_KEY = "https://ai-catalog.org/extensions/deployment"
+
+def resolve_url(entry, region=None, compliance=None, release_channel=None):
+    ext = entry.get("extensions", {}).get(DEPLOYMENT_KEY)
+    if not ext:
+        return entry["url"]  # extension unknown/absent — use default url
+
+    for inst in ext["instances"]:
+        if region and inst.get("region") != region:
+            continue
+        if compliance and compliance not in inst.get("compliance", []):
+            continue
+        if release_channel and inst.get("releaseChannel") != release_channel:
+            continue
+        return inst["url"]
+
+    return None  # policy unmet — do not fall back to a non-conforming instance
+```
+
+- If you **don't** understand the extension key, ignore it and fall back to the
+  entry's `url`.
+- If you **do** understand it but no instance satisfies your policy, do not
+  fall back to a non-conforming instance.
+- `dataResidency` and `compliance` are producer assertions, not signed claims.
+  Verify them via the entry's `trustManifest` when you need assurance.
+
 ## Handling nested catalogs
 
 An entry with `type: "application/ai-catalog+json"` is itself a catalog. To get all artifacts, recurse into it:

--- a/docs/guides/creating-a-catalog.md
+++ b/docs/guides/creating-a-catalog.md
@@ -231,6 +231,60 @@ Both the top-level catalog object and individual entries support a `metadata` fi
 
 Metadata keys should use reverse-DNS prefixes for vendor-specific keys (`com.acme.*`), or short unqualified names for broadly useful keys (`license`, `homepage`). Avoid shadowing standard fields like `displayName` or `tags`. Clients that don't recognize a key should ignore it.
 
+## The Deployment extension {#the-deployment-extension}
+
+When one logical artifact runs in several places — production and staging,
+`us-east-1` and `eu-west-1`, with differing data-residency and compliance
+constraints — describe those deployments with the **Deployment** official
+extension. The entry keeps a single stable `identifier`; the extension
+enumerates the concrete instances behind it.
+
+Official extensions live in the entry's `extensions` map, keyed by their
+namespace URL. The Deployment extension uses:
+
+```
+https://ai-catalog.org/extensions/deployment
+```
+
+Its value has a required, non-empty `instances` array. Each instance requires an
+`instanceId` (unique within the entry) and a `url`, plus optional `environment`,
+`releaseChannel`, `region`, `dataResidency`, `compliance`, and `description`:
+
+```json
+{
+  "identifier": "urn:air:acme-corp.com:agent:invoice-processor",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme-corp.com/agents/invoice",
+  "extensions": {
+    "https://ai-catalog.org/extensions/deployment": {
+      "instances": [
+        {
+          "instanceId": "invoice-prod-us",
+          "environment": "production",
+          "url": "https://api.acme-corp.com/agents/invoice",
+          "region": "us-east-1"
+        },
+        {
+          "instanceId": "invoice-prod-eu",
+          "environment": "production",
+          "url": "https://eu-api.acme-corp.com/agents/invoice",
+          "region": "eu-west-1",
+          "dataResidency": ["EU"],
+          "compliance": ["GDPR"]
+        }
+      ]
+    }
+  }
+}
+```
+
+The entry's top-level `url` stays the default entry point; each instance `url` is
+an alternative endpoint for the same artifact. Represent that default among the
+instances so one instance `url` equals the entry `url`.
+
+See [Deployment Metadata](../examples/deployment-metadata.md) for the full
+example and instance field reference.
+
 ## Complete example
 
 ```json

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Minimal Catalog: examples/minimal-catalog.md
       - Multi-Protocol Agent: examples/multi-protocol-agent.md
       - Nested Catalogs: examples/nested-catalogs.md
+      - Deployment Metadata: examples/deployment-metadata.md
   - Implementations: implementations.md
 
 

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -1155,9 +1155,147 @@ defines a set of "Official" known types for commonly requested schemas:
 
 1. **Metadata** (`https://ai-catalog.org/extensions/metadata`)
    - Used to store generic, schemaless key-value pairs.
+2. **Deployment** (`https://ai-catalog.org/extensions/deployment`)
+   - Declares the concrete deployment instances (environments, regions,
+     data-residency, and compliance) of the artifact identified by the
+     entry, enabling instance selection under a consumer's policy.
 
 As custom extensions become highly popular, the AI-Catalog TSC may promote
 them to Official Known Types or core standard fields in future specification versions.
+
+## Deployment Metadata Extension
+
+Official extension key: `https://ai-catalog.org/extensions/deployment`
+
+A single logical artifact identified by an entry's `identifier` is often
+deployed as more than one concrete instance. The SAME agent or server may
+run in development, staging, and production, and across multiple regions
+(e.g. `us-east-1`, `eu-west-1`) whose data-residency and compliance
+constraints differ. An entry's `identifier` and top-level `url` capture
+*what* the artifact is and its default entry point, but they do not
+express *where* it lives or under which constraints. The Deployment
+extension separates identity from instance: it enriches an entry with the
+set of deployment instances of that one logical artifact, so consumers can
+deterministically select an instance that matches their policy (e.g. EU
+clients targeting EU instances), exercise discovery against staging, or
+shadow-test a pre-release release channel (such as a beta or edge
+build) — all while the entry retains a single logical identity.
+
+The extension value is a JSON object appearing under the key
+`https://ai-catalog.org/extensions/deployment` in an entry's `extensions`
+map. It contains:
+
+`instances`
+: REQUIRED. An array of Instance objects. This array MUST be non-empty.
+
+Each Instance object contains:
+
+`instanceId`
+: REQUIRED. A string containing a stable identifier for this deployment
+  instance. It MUST be unique within the extension object.
+
+`url`
+: REQUIRED. A string containing the entry-point URL for this instance.
+
+`environment`
+: OPTIONAL. A string naming the deployment environment, e.g.
+  `"production"`, `"staging"`, `"development"`.
+
+`releaseChannel`
+: OPTIONAL. A string naming the release channel of this instance — the
+  maturity or stability track of the deployed version, orthogonal to the
+  `environment` it runs in. e.g. `"stable"`, `"beta"`, `"LTS"`, `"EDGE"`.
+
+`region`
+: OPTIONAL. A string naming the deployment region, e.g. `"us-east-1"`,
+  `"eu-west-1"`.
+
+`dataResidency`
+: OPTIONAL. An array of strings naming the jurisdictions where data is
+  stored or processed, e.g. `["EU"]`, `["US", "CA"]`.
+
+`compliance`
+: OPTIONAL. An array of strings naming the compliance regimes the instance
+  conforms to, e.g. `["GDPR"]`, `["SOC2", "HIPAA"]`.
+
+`description`
+: OPTIONAL. A string containing a human-readable label for the instance.
+
+The following rules apply:
+
+- The entry's top-level `url` remains the DEFAULT entry point for the
+  artifact. Each instance's `url` is an alternative endpoint for the SAME
+  logical artifact (the same `identifier`). Instances are deployments, NOT
+  distinct artifacts.
+- One of the listed instance `url` values SHOULD equal the entry's `url`
+  (the default instance). Producers SHOULD ensure the default entry-point
+  URL is represented among the instances.
+- A consumer that does not understand the extension key MUST ignore it and
+  fall back to the entry's `url`. This is guaranteed by the existing
+  extensions rule (see [Format and Key Naming](#format-and-key-naming)).
+- A consumer that DOES understand the extension MAY select an instance
+  whose `environment`, `releaseChannel`, `region`, `dataResidency`, or
+  `compliance` satisfies the consumer's policy. If no instance matches its policy, the
+  consumer SHOULD NOT fall back to a non-conforming instance — for
+  example, an EU-only client MUST NOT use a non-EU instance.
+- `instanceId` MUST be unique within the extension object.
+- Because this is deployment metadata, not a trust claim, it is unsigned
+  unless it appears in a Trust Manifest's `extensions`; it MUST NOT be
+  treated as a security control on its own. The `compliance` and
+  `dataResidency` values are producer assertions — a consumer needing
+  assurance verifies them via the Trust Manifest (attestations), not via
+  this extension.
+
+For example, an A2A agent deployed across regions and environments:
+
+```json
+{
+  "identifier": "urn:air:acme-corp.com:agent:invoice-processor",
+  "type": "application/a2a-agent-card+json",
+  "url": "https://api.acme-corp.com/agents/invoice",
+  "tags": ["finance", "a2a"],
+  "extensions": {
+    "https://ai-catalog.org/extensions/deployment": {
+      "instances": [
+        {
+          "instanceId": "invoice-prod-us",
+          "environment": "production",
+          "url": "https://api.acme-corp.com/agents/invoice",
+          "region": "us-east-1"
+        },
+        {
+          "instanceId": "invoice-prod-eu",
+          "environment": "production",
+          "url": "https://eu-api.acme-corp.com/agents/invoice",
+          "region": "eu-west-1",
+          "dataResidency": ["EU"],
+          "compliance": ["GDPR"]
+        },
+        {
+          "instanceId": "invoice-staging",
+          "environment": "staging",
+          "url": "https://staging-api.acme-corp.com/agents/invoice",
+          "region": "us-east-1",
+          "releaseChannel": "beta"
+        }
+      ]
+    }
+  }
+}
+```
+
+**Consumer selection.** A consumer that understands the extension filters
+`instances` by the attributes its policy constrains — selecting on
+`environment` to reach a staging deployment, on `releaseChannel` to prefer
+a `stable` build (or opt into a `beta` or `EDGE` one), on `region` for
+locality, and on `dataResidency` or `compliance` to honor regulatory
+obligations (e.g. an EU client keeps only instances whose `dataResidency`
+includes `"EU"`). It then uses a matching instance's `url` in place of the
+entry's default `url`. When the filter leaves no matching instance, the
+consumer SHOULD treat the artifact as unavailable for that request rather
+than fall back to a non-conforming instance or to the entry's default
+`url`; the no-unsafe-fallback rule ensures a compliance-constrained client
+never silently uses a deployment that violates its policy.
 
 # Version Handling
 
@@ -1489,7 +1627,14 @@ MUST treat it as untrusted input. In particular:
 
 Logo URLs SHOULD use Data URIs [[RFC2397]] to avoid leaking client
 information through image fetch requests. Publishers SHOULD carefully
-consider what information is included in `extensions` fields.
+consider what information is included in `extensions` fields. In
+particular, the Deployment extension's `region` and `dataResidency`
+values may reveal internal infrastructure topology, so publishers SHOULD
+expose only those instances intended for the catalog's audience.
+Furthermore, an instance's `compliance` and `dataResidency` values are
+unsigned producer assertions unless carried in a signed Trust Manifest, so
+a consumer needing assurance MUST corroborate them via attestations rather
+than trusting the extension alone.
 
 # Data Model Overview
 
@@ -1688,6 +1833,27 @@ Publisher = {
   identifier: text,
   displayName: text,
   ? identityType: text
+}
+```
+
+## Deployment Extension
+
+The following CDDL is INFORMATIVE. It describes the value of the
+`https://ai-catalog.org/extensions/deployment` entry in an `extensions`
+map (see [Deployment Metadata Extension](#deployment-metadata-extension)):
+
+```
+DeploymentExtension = { instances: [+ DeploymentInstance] }
+
+DeploymentInstance = {
+  instanceId: text,
+  url: text,
+  ? environment: text,
+  ? releaseChannel: text,
+  ? region: text,
+  ? dataResidency: [+ text],
+  ? compliance: [+ text],
+  ? description: text
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR resolves [#64](https://github.com/Agent-Card/ai-catalog/issues/64)
(structured deployment metadata) by adding an **official extension** —
`https://ai-catalog.org/extensions/deployment` — rather than a native
`instances` field on the Catalog Entry as the original proposal suggested.

A Catalog Entry conflates *identity* ("what the artifact is") with *instance*
("where it lives"). The same logical agent or server is routinely deployed
many times — across environments (development, staging, production), across
release channels (stable, beta, LTS, edge), and across regions (`us-east-1`,
`eu-west-1`) whose data-residency and compliance constraints differ. The
entry's `identifier` and top-level `url` capture the artifact and its default
entry point but cannot express these deployments. The extension lets a
publisher enumerate them on an entry so a consumer can deterministically
select an instance that satisfies its policy — an EU client targeting a GDPR
instance in `eu-west-1`, a test harness targeting `staging`, or a client
opting into a `beta` release channel — while the entry keeps a single logical
identity.

Because the extension is additive and unrecognized `extensions` keys are
ignored, it needs **no `specVersion` change** — a catalog carrying it remains
a conformant `1.0` document.

## Changes Included

1. **`adr/0022-deployment-metadata-extension.md`** (new) — records the
   decision to implement #64 as an official extension rather than a native
   entry field, consistent with the closed-core philosophy of
   [ADR-0012](adr/0012-extensibility-via-metadata.md).
2. **`specification/ai-catalog.md`**:
   - Registered the extension in the **Official Extensions** list alongside
     `metadata`.
   - Added the **Deployment Metadata Extension** section: value structure
     (a REQUIRED, non-empty `instances[]` array), the Instance object
     (`instanceId` and `url` REQUIRED; `environment`, `releaseChannel`,
     `region`, `dataResidency`, `compliance`, `description` OPTIONAL),
     selection semantics with a no-unsafe-fallback rule, and an example.
   - Added an informative **CDDL** block for the extension value.
   - Added a **Privacy Considerations** note on infrastructure-topology
     disclosure and unsigned producer assertions.
3. **Developer docs** — a new annotated example
   (`docs/examples/deployment-metadata.md`), an authoring section in
   *Creating a Catalog*, an instance-selection section in *Consuming
   Catalogs*, plus cross-links and a nav entry.

## Reconciling the original proposal

The proposal in #64 predates several current conventions; the extension uses
today's forms:

| Proposal (outdated) | This PR (current) |
|---|---|
| `urn:ai:…` | `urn:air:{publisher}:{namespace}:{name}` (ADR-0015) |
| native `instances` field on the entry | official `extensions` entry (keeps the core schema closed) |
| `compliance` as a bare string (`"GDPR"`) | `compliance` as a string array, matching `dataResidency` and allowing multiple regimes |
| "canary" discovery | `environment` (dev/staging/production) kept distinct from a new `releaseChannel` track (stable/beta/LTS/edge), since canary is a release strategy, not an environment tier |

## Design notes

- **Identity vs. instance.** Every instance is an alternative endpoint for the
  *same* `identifier`; instances are deployments, not distinct artifacts. The
  entry's top-level `url` remains the default entry point, and one instance
  `url` SHOULD equal it so the default is represented among the instances.
- **`environment` and `releaseChannel` are orthogonal.** `environment`
  describes *where* a version runs; `releaseChannel` describes the maturity
  track of the deployed version. Keeping them separate avoids overloading
  `environment` with release-strategy values.
- **Deployment metadata is not a trust control.** `dataResidency` and
  `compliance` are unsigned producer assertions unless carried in a signed
  Trust Manifest; a consumer that needs assurance MUST corroborate them via
  attestations, not via this extension.
- **No unsafe fallback.** A consumer that understands the extension MAY select
  an instance matching its policy; if none matches it SHOULD treat the
  artifact as unavailable for that request rather than fall back to a
  non-conforming instance — an EU-only client never silently uses a non-EU
  deployment.

## Interoperability impact

No change to interoperability expectations for existing catalogs. The core
schema, CDDL for core types, conformance levels, and `specVersion` are all
unchanged; a consumer that does not implement the extension ignores it without
error, exactly as for any unrecognized `extensions` key.

## Non-goals

- A deployment **resolver / load balancer** or health-checking behavior — this
  is discovery metadata only; the entry's `url` and each instance `url` remain
  ordinary references.
- Promoting deployment metadata to a **core field** — deliberately kept an
  extension per ADR-0012 / ADR-0022.
- Treating `compliance` / `dataResidency` as **enforceable guarantees** —
  they are producer assertions, verified (when needed) through the Trust
  Manifest.

## Validation

- `uv run --locked python tools/build_spec.py specification/ai-catalog.md dist/index.html --config specification/respec-config.json` — passes.
- `uv run --python 3.12 --locked --group docs mkdocs build --strict` — passes, no broken links.
- All deployment-bearing JSON examples validated.
