### PR TITLE
ci: add docs site PR preview mirroring live site structure

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - closed
     paths:
       - .github/workflows/publish-docs.yml
       - docs/**
@@ -33,6 +34,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
@@ -82,3 +84,102 @@ jobs:
             --cname ai-catalog.io \
             --remote-url "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
             --commit-message "Publish documentation site from main"
+
+  publish-pr-preview:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Build documentation site
+        run: |
+          uv run --python 3.12 --locked --group docs mkdocs build \
+            --site-dir ".site/pr/${{ github.event.pull_request.number }}" \
+            --strict
+
+      - name: Publish PR preview to gh-pages
+        run: |
+          python3 tools/update_gh_pages.py preview \
+            --source-dir ".site/pr/${{ github.event.pull_request.number }}" \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --remote-url "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
+            --commit-message "Publish documentation preview for PR #${{ github.event.pull_request.number }}"
+
+      - name: Comment preview URL on pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: https://ai-catalog.io/pr/${{ github.event.pull_request.number }}/
+        run: |
+          marker='<!-- ai-catalog-docs-preview -->'
+          body=$(cat <<EOF
+          ${marker}
+          Preview: ${PREVIEW_URL}
+
+          This comment is updated automatically while the pull request preview is available.
+          EOF
+          )
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --edit-last \
+            --create-if-none \
+            --body "$body"
+
+  cleanup-pr-preview:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Remove PR preview from gh-pages
+        run: |
+          python3 tools/update_gh_pages.py cleanup \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --remote-url "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
+            --commit-message "Remove documentation preview for PR #${{ github.event.pull_request.number }}"
+
+      - name: Update preview comment on pull request close
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          marker='<!-- ai-catalog-docs-preview -->'
+          body=$(cat <<EOF
+          ${marker}
+          Preview unavailable.
+
+          The pull request preview was removed because this pull request is closed.
+          EOF
+          )
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --edit-last \
+            --create-if-none \
+            --body "$body"

--- a/.github/workflows/publish-spec.yml
+++ b/.github/workflows/publish-spec.yml
@@ -150,16 +150,17 @@ jobs:
 
       - name: Publish PR preview to gh-pages
         run: |
-          python3 tools/update_gh_pages.py preview \
+          python3 tools/update_gh_pages.py preview-subdir \
             --source-dir ".site/pr/${{ github.event.pull_request.number }}" \
             --pr-number "${{ github.event.pull_request.number }}" \
+            --subdir-name spec \
             --remote-url "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
             --commit-message "Publish specification preview for PR #${{ github.event.pull_request.number }}"
 
       - name: Comment preview URL on pull request
         env:
           GH_TOKEN: ${{ github.token }}
-          PREVIEW_URL: https://ai-catalog.io/pr/${{ github.event.pull_request.number }}/
+          PREVIEW_URL: https://ai-catalog.io/pr/${{ github.event.pull_request.number }}/spec/
         run: |
           marker='<!-- ai-catalog-preview-url -->'
           body=$(cat <<EOF

--- a/tools/update_gh_pages.py
+++ b/tools/update_gh_pages.py
@@ -18,7 +18,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Update the gh-pages branch with canonical or PR preview content."
     )
-    parser.add_argument("mode", choices=("root", "preview", "cleanup", "subdir"))
+    parser.add_argument("mode", choices=("root", "preview", "preview-subdir", "cleanup", "subdir"))
     parser.add_argument(
         "--repo-root",
         type=Path,
@@ -129,9 +129,20 @@ def stage_subdir_publish(checkout_dir: Path, source_dir: Path, subdir_name: str)
 
 def stage_preview_publish(checkout_dir: Path, source_dir: Path, pr_number: int) -> None:
     preview_dir = checkout_dir / "pr" / str(pr_number)
-    remove_path(preview_dir)
+    if preview_dir.exists():
+        clear_root(preview_dir, {"spec"})
     preview_dir.mkdir(parents=True, exist_ok=True)
     copy_tree_contents(source_dir, preview_dir)
+    (checkout_dir / ".nojekyll").touch()
+
+
+def stage_preview_subdir_publish(
+    checkout_dir: Path, source_dir: Path, pr_number: int, subdir_name: str
+) -> None:
+    subdir = checkout_dir / "pr" / str(pr_number) / subdir_name
+    remove_path(subdir)
+    subdir.mkdir(parents=True, exist_ok=True)
+    copy_tree_contents(source_dir, subdir)
     (checkout_dir / ".nojekyll").touch()
 
 
@@ -203,6 +214,11 @@ def apply_mode(args: argparse.Namespace, checkout_dir: Path) -> None:
     if args.mode == "preview":
         stage_preview_publish(checkout_dir, args.source_dir.resolve(), args.pr_number)
         return
+    if args.mode == "preview-subdir":
+        stage_preview_subdir_publish(
+            checkout_dir, args.source_dir.resolve(), args.pr_number, args.subdir_name
+        )
+        return
     if args.mode == "subdir":
         stage_subdir_publish(checkout_dir, args.source_dir.resolve(), args.subdir_name)
         return
@@ -239,12 +255,12 @@ def publish_once(args: argparse.Namespace, branch_exists: bool) -> bool:
 
 
 def validate_args(args: argparse.Namespace) -> None:
-    if args.mode in {"root", "preview", "subdir"} and not args.source_dir:
-        raise SystemExit("--source-dir is required for root, preview, and subdir modes")
-    if args.mode in {"preview", "cleanup"} and args.pr_number is None:
-        raise SystemExit("--pr-number is required for preview and cleanup modes")
-    if args.mode == "subdir" and not args.subdir_name:
-        raise SystemExit("--subdir-name is required for subdir mode")
+    if args.mode in {"root", "preview", "preview-subdir", "subdir"} and not args.source_dir:
+        raise SystemExit("--source-dir is required for root, preview, preview-subdir, and subdir modes")
+    if args.mode in {"preview", "preview-subdir", "cleanup"} and args.pr_number is None:
+        raise SystemExit("--pr-number is required for preview, preview-subdir, and cleanup modes")
+    if args.mode in {"subdir", "preview-subdir"} and not args.subdir_name:
+        raise SystemExit("--subdir-name is required for subdir and preview-subdir modes")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

PR previews now mirror the live site layout:

| Path | Content |
|---|---|
| `ai-catalog.io/pr/<N>/` | MkDocs docs site preview |
| `ai-catalog.io/pr/<N>/spec/` | Rendered spec diff viewer |

Previously, only the spec diff was previewed and it deployed to the root of `pr/<N>/`, which didn't match the production structure.

### Changes

**`tools/update_gh_pages.py`**
- Add `preview-subdir` mode — deploys content to `pr/<N>/<subdir>/` without touching sibling directories (used by the spec workflow to deploy to `pr/<N>/spec/`)
- Update `preview` mode to preserve any existing `spec/` subdirectory inside `pr/<N>/` when the docs site deploys, preventing the two workflows from clobbering each other

**`.github/workflows/publish-spec.yml`**
- `publish-pr-preview`: switch from `preview` to `preview-subdir --subdir-name spec`
- Update PR comment URL from `/pr/<N>/` → `/pr/<N>/spec/`

**`.github/workflows/publish-docs.yml`**
- Add `closed` to PR trigger types
- Add `if` guard to `build` job to skip on PR close
- Add `publish-pr-preview` job: builds MkDocs and deploys to `pr/<N>/` using the updated `preview` mode (which preserves `spec/`)
- Add `cleanup-pr-preview` job: removes `pr/<N>/` on PR close and updates the docs preview comment