### PR TITLE
fix: make Agent Plugin entries retrievable

### DIFF
--- a/docs/guides/creating-a-catalog.md
+++ b/docs/guides/creating-a-catalog.md
@@ -89,10 +89,11 @@ Every entry must have these three things:
 | Agent Skill (Markdown) | `application/agent-skills+md` |
 | Agent Skill (ZIP bundle) | `application/agent-skills+zip` |
 | Agent Skill (gzipped tarball) | `application/agent-skills+gzip` |
-| Agent Plugin manifest | `application/agent-plugins+json` |
+| Agent Plugin (ZIP bundle) | `application/agent-plugins+zip` |
+| Agent Plugin (gzipped tarball) | `application/agent-plugins+gzip` |
 | Dataset | `application/parquet`, `text/csv`, or appropriate type |
 
-An **Agent Plugin** ([agent-plugins.org](https://agent-plugins.org)) is a portable package bundling Agent Skills and MCP servers into a single distributable unit. The catalog entry's `url` points to the plugin's `plugin.json` manifest — the machine-readable descriptor clients use for discovery. Loading and executing the full plugin requires the complete plugin directory, distributed out-of-band (e.g., via git or a package registry).
+An **Agent Plugin** ([agent-plugins.org](https://agent-plugins.org)) is directory-based. For AI Catalog delivery, archive the complete plugin directory as ZIP or gzipped tar, point the entry's `url` to that archive, and copy `plugin.json`'s `name`, `description`, and `keywords` to `displayName`, `description`, and `tags`, respectively; clients extract the archive before loading the plugin.
 
 This list is not exhaustive — AI Catalog accepts any string as a `type` value. The spec is intentionally artifact-agnostic.
 

--- a/specification/ai-catalog.md
+++ b/specification/ai-catalog.md
@@ -133,8 +133,10 @@ For example, a minimal catalog listing four AI artifacts:
     {
       "identifier": "urn:air:example.com:agent:productivity-plugin",
       "displayName": "Productivity Plugin",
-      "type": "application/agent-plugins+json",
-      "url": "https://plugins.example.com/productivity/plugin.json"
+      "type": "application/agent-plugins+zip",
+      "description": "Tools for common productivity workflows.",
+      "tags": ["productivity", "workflows"],
+      "url": "https://plugins.example.com/productivity.zip"
     }
   ]
 }
@@ -236,7 +238,8 @@ It MUST contain the following members:
     - `application/agent-skills+md` — an Agent Skill defined in a standard Markdown file (the suffix `+md` is to be registered)
     - `application/agent-skills+zip` — an Agent Skill bundle (ZIP archive)
     - `application/agent-skills+gzip` — an Agent Skill bundle (gzipped tarball)
-    - `application/agent-plugins+json` — an Agent Plugin manifest ([Agent Plugins specification](https://agent-plugins.org/specification))
+    - `application/agent-plugins+zip` — an Agent Plugin bundle (ZIP archive)
+    - `application/agent-plugins+gzip` — an Agent Plugin bundle (gzipped tarball)
 
     These values are designed to align with official IANA media type registration standards. Standard ecosystem types use registered structured syntax suffixes (`+json`, `+zip`, `+gzip`). For any new or custom types not listed here, it is up to the specific client implementation to handle them correctly.
 
@@ -259,9 +262,11 @@ The following members are OPTIONAL:
 : A string containing a human-readable name for the artifact.
   This field SHOULD be set only when the referenced artifact does not
   already carry its own canonical human-readable name — for example a
-  raw dataset (`application/parquet`), a model blob, or a skill bundle
-  (`application/agent-skills+zip`), none of which embed a self-describing
-  name. When the referenced artifact does carry such a name — for
+  raw dataset (`application/parquet`), a model blob, a skill bundle
+  (`application/agent-skills+zip`), or an Agent Plugin bundle
+  (`application/agent-plugins+zip`), none of which directly expose a
+  self-describing name without processing the artifact. When the referenced
+  artifact does carry such a name — for
   example the `name` field of an A2A Agent Card or the `title` field of
   an MCP Server Card — that artifact is the authoritative source and
   `displayName` SHOULD be omitted to avoid duplicating a value that can

--- a/specification/examples/ai-catalog.json
+++ b/specification/examples/ai-catalog.json
@@ -55,7 +55,7 @@
     {
       "identifier": "urn:air:acme-corp.com:plugin:finance-assistant-plugin",
       "displayName": "Finance Assistant Plugin",
-      "type": "application/agent-plugins+json",
+      "type": "application/agent-plugins+zip",
       "description": "Agent Plugin bundle with skills and MCP server for finance workflows.",
       "tags": [
         "finance",
@@ -63,7 +63,7 @@
         "skills",
         "mcp"
       ],
-      "url": "https://plugins.acme-corp.com/finance-assistant/plugin.json",
+      "url": "https://plugins.acme-corp.com/finance-assistant.zip",
       "updatedAt": "2026-02-22T16:00:00Z"
     }
   ]


### PR DESCRIPTION
Catalog URLs are defined to return the complete artifact bytes, but manifest-only entries left consumers without a way to acquire plugin components.

Replace the JSON manifest type with ZIP and gzip bundle types.