### PR TITLE
docs: add starter MAINTAINERS.md for SDK and CLI projects

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+# AI Catalog Maintainers
+
+The individuals listed below have committed to maintaining these projects; contributors interested in working on a project should look to its named maintainers for guidance.
+
+| Project | Repository | Lead Maintainers |
+| :--- | :--- | :--- |
+| Rust SDK | https://github.com/Agent-Card/ai-catalog-rust | Luca Muscariello (https://github.com/muscariello), Jeffrey Damick (https://github.com/jdamick) |
+| Go SDK | https://github.com/Agent-Card/ai-catalog-go | Luca Muscariello (https://github.com/muscariello), Jeffrey Damick (https://github.com/jdamick) |
+| CLI | https://github.com/Agent-Card/ai-catalog-cli | Luca Muscariello (https://github.com/muscariello) |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,34 @@
 
 The individuals listed below have committed to maintaining these projects; contributors interested in working on a project should look to its named maintainers for guidance.
 
-| Project | Repository | Lead Maintainers |
+## Rust SDK
+
+Repository: [Agent-Card/ai-catalog-rust](https://github.com/Agent-Card/ai-catalog-rust)
+
+Lead Maintainers:
+
+| Company | Representative | Contact |
 | :--- | :--- | :--- |
-| Rust SDK | https://github.com/Agent-Card/ai-catalog-rust | Luca Muscariello (https://github.com/muscariello), Jeffrey Damick (https://github.com/jdamick) |
-| Go SDK | https://github.com/Agent-Card/ai-catalog-go | Luca Muscariello (https://github.com/muscariello), Jeffrey Damick (https://github.com/jdamick) |
-| CLI | https://github.com/Agent-Card/ai-catalog-cli | Luca Muscariello (https://github.com/muscariello) |
+| Cisco | Luca Muscariello | [@muscariello](https://github.com/muscariello) |
+| AWS | Jeffrey Damick | [@jdamick](https://github.com/jdamick) |
+
+## Go SDK
+
+Repository: [Agent-Card/ai-catalog-go](https://github.com/Agent-Card/ai-catalog-go)
+
+Lead Maintainers:
+
+| Company | Representative | Contact |
+| :--- | :--- | :--- |
+| Cisco | Luca Muscariello | [@muscariello](https://github.com/muscariello) |
+| AWS | Jeffrey Damick | [@jdamick](https://github.com/jdamick) |
+
+## CLI
+
+Repository: [Agent-Card/ai-catalog-cli](https://github.com/Agent-Card/ai-catalog-cli)
+
+Lead Maintainers:
+
+| Company | Representative | Contact |
+| :--- | :--- | :--- |
+| Cisco | Luca Muscariello | [@muscariello](https://github.com/muscariello) |


### PR DESCRIPTION
Starts a `MAINTAINERS.md` at the repo root with the three projects now living in this org, and the individuals who have committed to maintaining them. This is a starting point so we have clear ownership to ensure official projects are actively maintained; we might consider e.g. demoting a project from "official" status if there is not an active, trusted lead maintainer.

## Basis for the list

Taken from the volunteering thread in #89:

- **Luca Muscariello ([@muscariello](https://github.com/muscariello))** — *"I can volunteer for both (Rust and Go) and I'd be happy to have others join"*
- **Jeffrey Damick ([@jdamick](https://github.com/jdamick))** — *"I'd volunteer to help out on these"* and *"yes, i'm comfortable with go, rust, java, whatever."*

And per discussion at August 27, 2026 meeting, setting Luca as sole maintainer on the CLI for now.